### PR TITLE
feat: config pass by ref

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -83,3 +83,9 @@ impl Default for Config {
         }
     }
 }
+
+impl AsRef<Config> for Config {
+    fn as_ref(&self) -> &Config {
+        self
+    }
+}

--- a/cli/src/handler.rs
+++ b/cli/src/handler.rs
@@ -16,7 +16,10 @@ pub trait Handler {
     type Error;
     type Response;
 
-    async fn handle(self, config: Config) -> Result<Self::Response, Self::Error>;
+    async fn handle<C: AsRef<Config> + Send>(
+        self,
+        config: C,
+    ) -> Result<Self::Response, Self::Error>;
 }
 
 #[async_trait]
@@ -24,7 +27,10 @@ impl Handler for Request {
     type Error = Error;
     type Response = Response;
 
-    async fn handle(self, config: Config) -> Result<Self::Response, Self::Error> {
+    async fn handle<C: AsRef<Config> + Send>(
+        self,
+        config: C,
+    ) -> Result<Self::Response, Self::Error> {
         match self {
             Request::Init(request) => request.handle(config).await,
             Request::Handshake(request) => request.handle(config).await,

--- a/cli/src/handler/contract_build.rs
+++ b/cli/src/handler/contract_build.rs
@@ -16,7 +16,12 @@ impl Handler for ContractBuildRequest {
     type Error = Error;
     type Response = Response;
 
-    async fn handle(self, config: Config) -> Result<Self::Response, Self::Error> {
+    async fn handle<C: AsRef<Config> + Send>(
+        self,
+        config: C,
+    ) -> Result<Self::Response, Self::Error> {
+        let config = config.as_ref();
+
         let mut cargo = Command::new("cargo");
         let command = cargo
             .arg("wasm")

--- a/cli/src/handler/enclave_build.rs
+++ b/cli/src/handler/enclave_build.rs
@@ -16,7 +16,12 @@ impl Handler for EnclaveBuildRequest {
     type Error = Error;
     type Response = Response;
 
-    async fn handle(self, config: Config) -> Result<Self::Response, Self::Error> {
+    async fn handle<C: AsRef<Config> + Send>(
+        self,
+        config: C,
+    ) -> Result<Self::Response, Self::Error> {
+        let config = config.as_ref();
+
         let mut cargo = Command::new("cargo");
         let command = cargo
             .args(["build", "--release"])

--- a/cli/src/handler/enclave_start.rs
+++ b/cli/src/handler/enclave_start.rs
@@ -17,7 +17,11 @@ impl Handler for EnclaveStartRequest {
     type Error = Error;
     type Response = Response;
 
-    async fn handle(self, mut config: Config) -> Result<Self::Response, Self::Error> {
+    async fn handle<C: AsRef<Config> + Send>(
+        self,
+        config: C,
+    ) -> Result<Self::Response, Self::Error> {
+        let mut config = config.as_ref().clone();
         // Get trusted height and hash
         let (trusted_height, trusted_hash) = get_hash_height(self.use_latest_trusted, &mut config)?;
 

--- a/cli/src/handler/handshake.rs
+++ b/cli/src/handler/handshake.rs
@@ -32,7 +32,12 @@ impl Handler for HandshakeRequest {
     type Error = Error;
     type Response = Response;
 
-    async fn handle(self, config: Config) -> Result<Self::Response, Self::Error> {
+    async fn handle<C: AsRef<Config> + Send>(
+        self,
+        config: C,
+    ) -> Result<Self::Response, Self::Error> {
+        let config = config.as_ref().clone();
+
         trace!("starting handshake...");
 
         // TODO: may need to import verbosity here

--- a/cli/src/handler/init.rs
+++ b/cli/src/handler/init.rs
@@ -18,7 +18,12 @@ impl Handler for InitRequest {
     type Error = Error;
     type Response = Response;
 
-    async fn handle(self, config: Config) -> Result<Self::Response, Self::Error> {
+    async fn handle<C: AsRef<Config> + Send>(
+        self,
+        config: C,
+    ) -> Result<Self::Response, Self::Error> {
+        let config = config.as_ref();
+
         trace!("initializing directory structure...");
 
         let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");

--- a/cosmwasm/packages/tcbinfo/src/contract.rs
+++ b/cosmwasm/packages/tcbinfo/src/contract.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
 };
 use cw2::set_contract_version;
 use der::{DateTime, DecodePem};
-use mc_attestation_verifier::{CertificateChainVerifier, SignedTcbInfo, TcbInfo as McTcbInfo};
+use mc_attestation_verifier::{CertificateChainVerifier, SignedTcbInfo};
 use p256::ecdsa::VerifyingKey;
 use quartz_tee_ra::intel_sgx::dcap::certificate_chain::TlsCertificateChainVerifier;
 use serde_json::Value;

--- a/utils/cycles-sync/src/wasmd_client.rs
+++ b/utils/cycles-sync/src/wasmd_client.rs
@@ -47,7 +47,7 @@ pub trait WasmdClient {
         &self,
         chain_id: &Id,
         sender: &str,
-        code_id: usize,
+        code_id: u64,
         init_msg: M,
         label: &str,
     ) -> Result<String, Self::Error>;
@@ -201,7 +201,7 @@ impl WasmdClient for CliWasmdClient {
         &self,
         chain_id: &Id,
         sender: &str,
-        code_id: usize,
+        code_id: u64,
         init_msg: M,
         label: &str,
     ) -> Result<String, Self::Error> {


### PR DESCRIPTION
## Summary
A problem arose where in `dev` I was forced to repeatedly `clone()` the config in order to call the other commands' handlers. 

## Changes
- Changed the handler function signature to a generic type which implements `AsRef<Config>` and `Send`. 
- To use the config struct in each handler implementation, I call `let config = config.as_ref()`. 
  - `.clone()` is used whenever the config needs to be owned in order to make a mutable borrow (mutable borrows are needed when potentially updating the trusted hash/height in the config)
  
 Made this as a separate PR since it spans across other commands and I wanted to confirm that my changes fell in line with Rust idioms. 