### PR TITLE
Add empty params to init_clearing

### DIFF
--- a/apps/mtcs/contracts/cw-tee-mtcs/src/contract.rs
+++ b/apps/mtcs/contracts/cw-tee-mtcs/src/contract.rs
@@ -93,7 +93,7 @@ pub fn execute(
             let SubmitSetoffsMsg { setoffs_enc } = attested_msg.msg.0;
             execute::submit_setoffs(deps, env, setoffs_enc)
         }
-        ExecuteMsg::InitClearing => execute::init_clearing(deps),
+        ExecuteMsg::InitClearing {} => execute::init_clearing(deps),
         ExecuteMsg::SetLiquiditySources(SetLiquiditySourcesMsg { liquidity_sources }) => {
             execute::append_liquidity_sources(deps, liquidity_sources)?;
             Ok(Response::new())

--- a/apps/mtcs/contracts/cw-tee-mtcs/src/msg.rs
+++ b/apps/mtcs/contracts/cw-tee-mtcs/src/msg.rs
@@ -25,7 +25,7 @@ pub enum ExecuteMsg<RA = RawDefaultAttestation> {
     SubmitObligation(execute::SubmitObligationMsg),
     SubmitObligations(execute::SubmitObligationsMsg),
     SubmitSetoffs(AttestedMsg<execute::SubmitSetoffsMsg, RA>),
-    InitClearing,
+    InitClearing {},
     SetLiquiditySources(execute::SetLiquiditySourcesMsg),
 }
 


### PR DESCRIPTION
Without these changes I was able to execute the message with command line, but not in code.

I'm not sure about the conventions of the rust code, but with these changes I am able to do the call in code avoiding the the following errors:

1. using the message: `msg: "init_clearing"` ---> Error: `payload msg: invalid`
2. using the message: `msg: {"init_clearing": {}}` ---> Error: `failed to execute message; message index: 0: Error parsing into type cw_tee_mtcs::msg::ExecuteMsg: Invalid type:`