### PR TITLE
Revert "Add empty params to init_clearing (#176)"

### DIFF
--- a/apps/mtcs/contracts/cw-tee-mtcs/src/contract.rs
+++ b/apps/mtcs/contracts/cw-tee-mtcs/src/contract.rs
@@ -93,7 +93,7 @@ pub fn execute(
             let SubmitSetoffsMsg { setoffs_enc } = attested_msg.msg.0;
             execute::submit_setoffs(deps, env, setoffs_enc)
         }
-        ExecuteMsg::InitClearing {} => execute::init_clearing(deps),
+        ExecuteMsg::InitClearing => execute::init_clearing(deps),
         ExecuteMsg::SetLiquiditySources(SetLiquiditySourcesMsg { liquidity_sources }) => {
             execute::append_liquidity_sources(deps, liquidity_sources)?;
             Ok(Response::new())

--- a/apps/mtcs/contracts/cw-tee-mtcs/src/msg.rs
+++ b/apps/mtcs/contracts/cw-tee-mtcs/src/msg.rs
@@ -25,7 +25,7 @@ pub enum ExecuteMsg<RA = RawDefaultAttestation> {
     SubmitObligation(execute::SubmitObligationMsg),
     SubmitObligations(execute::SubmitObligationsMsg),
     SubmitSetoffs(AttestedMsg<execute::SubmitSetoffsMsg, RA>),
-    InitClearing {},
+    InitClearing,
     SetLiquiditySources(execute::SetLiquiditySourcesMsg),
 }
 


### PR DESCRIPTION
This reverts commit 302008c337b58fcad0373922a2787b9341eafd58.
The change was not needed.