### PR TITLE
Add empty brackets to GetAllSetoffs query

### DIFF
--- a/apps/mtcs/contracts/cw-tee-mtcs/src/contract.rs
+++ b/apps/mtcs/contracts/cw-tee-mtcs/src/contract.rs
@@ -337,7 +337,7 @@ pub mod execute {
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::GetAllSetoffs => to_json_binary(&query::get_all_setoffs(deps)?),
+        QueryMsg::GetAllSetoffs {} => to_json_binary(&query::get_all_setoffs(deps)?),
         QueryMsg::GetLiquiditySources { epoch } => {
             to_json_binary(&query::get_liquidity_sources(deps, epoch)?)
         }

--- a/apps/mtcs/contracts/cw-tee-mtcs/src/msg.rs
+++ b/apps/mtcs/contracts/cw-tee-mtcs/src/msg.rs
@@ -138,7 +138,7 @@ pub mod execute {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(GetAllSetoffsResponse)]
-    GetAllSetoffs,
+    GetAllSetoffs {},
     #[returns(GetLiquiditySourcesResponse)]
     GetLiquiditySources { epoch: Option<Uint64> }, // `None` means latest
     #[returns(cw20::BalanceResponse)]


### PR DESCRIPTION
We might need empty brackets for queries.

How can we test it?