### PR TITLE
fix(enclave): proto build

### DIFF
--- a/crates/enclave/proto/Cargo.toml
+++ b/crates/enclave/proto/Cargo.toml
@@ -17,7 +17,7 @@ Protobuf types defining the Quartz handshake to initialize connection between a 
 
 [dependencies]
 # external
-prost.workspace = true
+prost = { workspace = true, features = ["derive"] }
 tonic.workspace = true
 
 [build-dependencies]


### PR DESCRIPTION
Not sure why this wasn't showing up otherwise, but the quartz-proto crate was missing a prost feature and failed to build (when built individually).