### PR TITLE
feat: Azure focal support

### DIFF
--- a/crates/cli/src/bin/gen-quote.manifest.template
+++ b/crates/cli/src/bin/gen-quote.manifest.template
@@ -25,7 +25,7 @@ fs.mounts = [
 ]
 
 sgx.enclave_size = "512M"
-sgx.max_threads = 2
+sgx.max_threads = 4
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.remote_attestation = "{{ ra_type }}"

--- a/crates/cli/src/bin/gen-quote.manifest.template
+++ b/crates/cli/src/bin/gen-quote.manifest.template
@@ -3,7 +3,7 @@
 libos.entrypoint = "{{ gen_quote_bin_path }}"
 
 loader.log_level = "{{ log_level }}"
-loader.entrypoint = "file:{{ gramine.libos }}"
+loader.entrypoint.uri = "file:{{ gramine.libos }}"
 loader.env.LD_LIBRARY_PATH = "/lib:/usr/local/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 loader.env.HOME = "{{ home }}"
 loader.env.INSIDE_SGX = "1"

--- a/crates/cli/src/bin/gen-quote.manifest.template
+++ b/crates/cli/src/bin/gen-quote.manifest.template
@@ -29,7 +29,6 @@ sgx.max_threads = 4
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.remote_attestation = "{{ ra_type }}"
-sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -215,6 +215,7 @@ pub struct EnclaveBuildArgs {
     pub release: bool,
 }
 
+#[serde_as]
 #[derive(Debug, Parser, Clone, Serialize, Deserialize)]
 pub struct EnclaveStartArgs {
     /// The network chain ID
@@ -230,6 +231,12 @@ pub struct EnclaveStartArgs {
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fmspc: Option<Fmspc>,
+
+    /// PCCS URL; required if `MOCK_SGX` is not set
+    #[arg(long)]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pccs_url: Option<Url>,
 
     /// Address of the TcbInfo contract
     #[arg(long)]

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -81,7 +81,7 @@ pub enum Command {
     Dev(DevArgs),
 
     /// Print the FMSPC of the current platform (SGX only)
-    PrintFmspc,
+    PrintFmspc(PrintFmspcArgs),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -279,6 +279,16 @@ pub struct DevArgs {
     pub dcap_verifier_contract: Option<AccountId>,
 }
 
+#[serde_as]
+#[derive(Debug, Parser, Clone, Serialize, Deserialize)]
+pub struct PrintFmspcArgs {
+    /// PCCS URL
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub pccs_url: Option<Url>,
+}
+
 pub trait ToFigment {
     fn to_figment(&self) -> Figment;
 }
@@ -299,7 +309,7 @@ impl ToFigment for Command {
             Command::Dev(args) => Figment::from(Serialized::defaults(args))
                 .merge(Serialized::defaults(&args.contract_deploy))
                 .merge(Serialized::defaults(&args.enclave_build)),
-            Command::PrintFmspc => Figment::default(),
+            Command::PrintFmspc(args) => Figment::from(Serialized::defaults(args)),
         }
     }
 }

--- a/crates/cli/src/handler/dev.rs
+++ b/crates/cli/src/handler/dev.rs
@@ -162,6 +162,7 @@ fn spawn_enclave_start(args: &DevRequest, config: &Config) -> Result<()> {
     let enclave_start = EnclaveStartRequest {
         unsafe_trust_latest: args.unsafe_trust_latest,
         fmspc: args.fmspc.clone(),
+        pccs_url: None,
         tcbinfo_contract: args.tcbinfo_contract.clone(),
         dcap_verifier_contract: args.dcap_verifier_contract.clone(),
     };

--- a/crates/cli/src/handler/enclave_start.rs
+++ b/crates/cli/src/handler/enclave_start.rs
@@ -21,6 +21,8 @@ use crate::{
     response::{enclave_start::EnclaveStartResponse, Response},
 };
 
+const DEFAULT_PCCS_URL: &str = "https://localhost:8081/sgx/certification/v4/";
+
 #[async_trait]
 impl Handler for EnclaveStartRequest {
     type Response = Response;
@@ -73,6 +75,10 @@ impl Handler for EnclaveStartRequest {
                 ));
             };
 
+            let pccs_url = self
+                .pccs_url
+                .unwrap_or(DEFAULT_PCCS_URL.parse().expect("hardcoded URL"));
+
             if std::env::var("ADMIN_SK").is_err() {
                 return Err(eyre!("ADMIN_SK environment variable is not set"));
             };
@@ -94,6 +100,7 @@ impl Handler for EnclaveStartRequest {
                 quartz_dir_canon,
                 &enclave_dir,
                 fmspc,
+                pccs_url,
                 tcbinfo_contract,
                 dcap_verifier_contract,
                 &config.node_url,
@@ -180,6 +187,7 @@ async fn gramine_manifest(
     quartz_dir: &Path,
     enclave_dir: &Path,
     fmspc: Fmspc,
+    pccs_url: Url,
     tcbinfo_contract: AccountId,
     dcap_verifier_contract: AccountId,
     node_url: &Url,
@@ -208,6 +216,7 @@ async fn gramine_manifest(
         .arg(format!("-Dtrusted_height={}", trusted_height))
         .arg(format!("-Dtrusted_hash={}", trusted_hash))
         .arg(format!("-Dfmspc={}", hex::encode(fmspc)))
+        .arg(format!("-Dpccs_url={}", pccs_url))
         .arg(format!("-Dnode_url={}", node_url))
         .arg(format!("-Dws_url={}", ws_url))
         .arg(format!("-Dgrpc_url={}", grpc_url))

--- a/crates/cli/src/handler/enclave_start.rs
+++ b/crates/cli/src/handler/enclave_start.rs
@@ -210,7 +210,6 @@ async fn gramine_manifest(
         .arg(format!("-Dhome={}", home_dir))
         .arg(format!("-Darch_libdir={}", arch_libdir))
         .arg("-Dra_type=dcap")
-        .arg("-Dra_client_linkable=1")
         .arg(format!("-Dchain_id={}", chain_id))
         .arg(format!("-Dquartz_dir={}", quartz_dir.display()))
         .arg(format!("-Dtrusted_height={}", trusted_height))

--- a/crates/cli/src/handler/print_fmspc.rs
+++ b/crates/cli/src/handler/print_fmspc.rs
@@ -92,7 +92,6 @@ impl Handler for PrintFmspcRequest {
             .arg(format!("-Dhome={}", home_dir))
             .arg(format!("-Darch_libdir={}", arch_libdir))
             .arg("-Dra_type=dcap")
-            .arg("-Dra_client_linkable=1")
             .arg(format!(
                 "-Dgen_quote_bin_path={}",
                 gen_quote_bin_path.display()

--- a/crates/cli/src/handler/print_fmspc.rs
+++ b/crates/cli/src/handler/print_fmspc.rs
@@ -148,10 +148,9 @@ impl Handler for PrintFmspcRequest {
         let url = self
             .pccs_url
             .unwrap_or(DEFAULT_PCCS_URL.parse().expect("hardcoded URL"));
-        let collateral =
-            get_collateral(&url.to_string(), &quote, std::time::Duration::from_secs(10))
-                .await
-                .expect("failed to get collateral");
+        let collateral = get_collateral(url.as_str(), &quote, std::time::Duration::from_secs(10))
+            .await
+            .expect("failed to get collateral");
         let tcb_info: serde_json::Value = serde_json::from_str(&collateral.tcb_info)
             .expect("Retrieved Tcbinfo is not valid JSON");
 

--- a/crates/cli/src/handler/print_fmspc.rs
+++ b/crates/cli/src/handler/print_fmspc.rs
@@ -145,9 +145,11 @@ impl Handler for PrintFmspcRequest {
         }
 
         let quote = hex::decode(output.stdout)?;
-
+        let url = self
+            .pccs_url
+            .unwrap_or(DEFAULT_PCCS_URL.parse().expect("hardcoded URL"));
         let collateral =
-            get_collateral(DEFAULT_PCCS_URL, &quote, std::time::Duration::from_secs(10))
+            get_collateral(&url.to_string(), &quote, std::time::Duration::from_secs(10))
                 .await
                 .expect("failed to get collateral");
         let tcb_info: serde_json::Value = serde_json::from_str(&collateral.tcb_info)

--- a/crates/cli/src/request.rs
+++ b/crates/cli/src/request.rs
@@ -65,7 +65,9 @@ impl TryFrom<Command> for Request {
                 }
                 .into())
             }
-            Command::PrintFmspc => Ok(Request::PrintFmspc(PrintFmspcRequest)),
+            Command::PrintFmspc(args) => Ok(Request::PrintFmspc(PrintFmspcRequest {
+                pccs_url: args.pccs_url,
+            })),
         }
     }
 }

--- a/crates/cli/src/request.rs
+++ b/crates/cli/src/request.rs
@@ -118,6 +118,7 @@ impl TryFrom<EnclaveCommand> for Request {
             EnclaveCommand::Start(args) => Ok(EnclaveStartRequest {
                 unsafe_trust_latest: args.unsafe_trust_latest,
                 fmspc: args.fmspc,
+                pccs_url: args.pccs_url,
                 tcbinfo_contract: args.tcbinfo_contract,
                 dcap_verifier_contract: args.dcap_verifier_contract,
             }

--- a/crates/cli/src/request/enclave_start.rs
+++ b/crates/cli/src/request/enclave_start.rs
@@ -1,6 +1,7 @@
 use color_eyre::Result;
 use cosmrs::AccountId;
 use quartz_common::enclave::types::Fmspc;
+use reqwest::Url;
 use tendermint::{block::Height, Hash};
 use tracing::debug;
 
@@ -10,6 +11,7 @@ use crate::{config::Config, handler::utils::helpers::query_latest_height_hash, r
 pub struct EnclaveStartRequest {
     pub unsafe_trust_latest: bool,
     pub fmspc: Option<Fmspc>,
+    pub pccs_url: Option<Url>,
     pub tcbinfo_contract: Option<AccountId>,
     pub dcap_verifier_contract: Option<AccountId>,
 }

--- a/crates/cli/src/request/print_fmspc.rs
+++ b/crates/cli/src/request/print_fmspc.rs
@@ -1,7 +1,11 @@
+use reqwest::Url;
+
 use crate::request::Request;
 
 #[derive(Clone, Debug)]
-pub struct PrintFmspcRequest;
+pub struct PrintFmspcRequest {
+    pub pccs_url: Option<Url>,
+}
 
 impl From<PrintFmspcRequest> for Request {
     fn from(request: PrintFmspcRequest) -> Self {

--- a/crates/enclave/core/README.md
+++ b/crates/enclave/core/README.md
@@ -12,7 +12,6 @@ gramine-manifest  \
     -Dhome=${HOME}  \
     -Darch_libdir="/lib/$(gcc -dumpmachine)"  \
     -Dra_type="dcap" \
-    -Dra_client_linkable=1 \
     -Dquartz_dir="$(pwd)"  \
     quartz.manifest.template quartz.manifest
 

--- a/crates/enclave/core/src/attestor.rs
+++ b/crates/enclave/core/src/attestor.rs
@@ -73,8 +73,8 @@ impl Attestor for DcapAttestor {
     }
 
     fn attestation(&self, user_data: impl HasUserData) -> Result<Self::Attestation, Self::Error> {
-        fn pccs_query_pck(mut pccs_url: Url) -> Result<(Vec<u8>, String), Box<dyn Error>> {
-            pccs_url.set_path("pckcrl");
+        fn pccs_query_pck(pccs_url: Url) -> Result<(Vec<u8>, String), Box<dyn Error>> {
+            let mut pccs_url = pccs_url.join("pckcrl/").expect("hardcoded URL");
             pccs_url.set_query(Some("ca=processor"));
 
             let client = Client::builder()

--- a/docker/enclave-sgx/Dockerfile
+++ b/docker/enclave-sgx/Dockerfile
@@ -54,8 +54,7 @@ RUN gramine-sgx-gen-private-key > /dev/null 2>&1 && \
         -Denclave_dir="/opt/enclave"  \
         -Denclave_executable="/opt/enclave/bin/enclave" \
         -Darch_libdir="/lib/$(gcc -dumpmachine)"  \
-        -Dra_type="epid" \
-        -Dra_client_linkable=1 \
+        -Dra_type="dcap" \
         -Dtrusted_height="${TRUSTED_HEIGHT}"  \
         -Dtrusted_hash="${TRUSTED_HASH}"  \
         -Dgramine_port=11090 \

--- a/examples/pingpong/enclave/quartz.manifest.template
+++ b/examples/pingpong/enclave/quartz.manifest.template
@@ -1,6 +1,6 @@
 # Quartz-based app manifest file
 
-loader.entrypoint = "file:{{ gramine.libos }}"
+loader.entrypoint.uri = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ quartz_dir }}/target/release/quartz-app-transfers-enclave"
 
 loader.log_level = "{{ log_level }}"

--- a/examples/pingpong/enclave/quartz.manifest.template
+++ b/examples/pingpong/enclave/quartz.manifest.template
@@ -26,6 +26,7 @@ loader.insecure__use_host_env = true
 loader.argv = ["quartz-app-transfers-enclave",
                 "--chain-id", "{{ chain_id }}",
                 "--fmspc", "{{ fmspc }}",
+                "--pccs-url", "{{ pccs_url }}",
                 "--tcbinfo-contract", "{{ tcbinfo_contract }}",
                 "--dcap-verifier-contract", "{{ dcap_verifier_contract }}",
                 "--node-url", "{{ node_url }}",

--- a/examples/pingpong/enclave/quartz.manifest.template
+++ b/examples/pingpong/enclave/quartz.manifest.template
@@ -51,8 +51,6 @@ sgx.max_threads = 16
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.remote_attestation = "{{ ra_type }}"
-sgx.ra_client_spid = "{{ ra_client_spid }}"
-sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/examples/pingpong/enclave/src/cli.rs
+++ b/examples/pingpong/enclave/src/cli.rs
@@ -33,6 +33,10 @@ pub struct Cli {
     #[clap(long)]
     pub fmspc: Option<Fmspc>,
 
+    /// PCCS URL (for DCAP)
+    #[clap(long)]
+    pub pccs_url: Option<Url>,
+
     /// TcbInfo contract address
     #[clap(long)]
     pub tcbinfo_contract: Option<AccountId>,

--- a/examples/pingpong/enclave/src/main.rs
+++ b/examples/pingpong/enclave/src/main.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(not(feature = "mock-sgx"))]
     let attestor = attestor::DcapAttestor {
         fmspc: args.fmspc.expect("FMSPC is required for DCAP"),
+        pccs_url: args.pccs_url.expect("PCCS URL is required for DCAP"),
     };
 
     #[cfg(feature = "mock-sgx")]

--- a/examples/transfers/enclave/quartz.manifest.template
+++ b/examples/transfers/enclave/quartz.manifest.template
@@ -1,6 +1,6 @@
 # Quartz-based app manifest file
 
-loader.entrypoint = "file:{{ gramine.libos }}"
+loader.entrypoint.uri = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ quartz_dir }}/target/release/quartz-app-transfers-enclave"
 
 loader.log_level = "{{ log_level }}"

--- a/examples/transfers/enclave/quartz.manifest.template
+++ b/examples/transfers/enclave/quartz.manifest.template
@@ -26,6 +26,7 @@ loader.insecure__use_host_env = true
 loader.argv = ["quartz-app-transfers-enclave",
                 "--chain-id", "{{ chain_id }}",
                 "--fmspc", "{{ fmspc }}",
+                "--pccs-url", "{{ pccs_url }}",
                 "--tcbinfo-contract", "{{ tcbinfo_contract }}",
                 "--dcap-verifier-contract", "{{ dcap_verifier_contract }}",
                 "--node-url", "{{ node_url }}",

--- a/examples/transfers/enclave/quartz.manifest.template
+++ b/examples/transfers/enclave/quartz.manifest.template
@@ -51,7 +51,6 @@ sgx.max_threads = 16
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 
 sgx.remote_attestation = "{{ ra_type }}"
-sgx.ra_client_linkable = {{ 'true' if ra_client_linkable == '1' else 'false' }}
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/examples/transfers/enclave/src/cli.rs
+++ b/examples/transfers/enclave/src/cli.rs
@@ -33,6 +33,10 @@ pub struct Cli {
     #[clap(long)]
     pub fmspc: Option<Fmspc>,
 
+    /// PCCS URL (for DCAP)
+    #[clap(long)]
+    pub pccs_url: Option<Url>,
+
     /// TcbInfo contract address
     #[clap(long)]
     pub tcbinfo_contract: Option<AccountId>,

--- a/examples/transfers/enclave/src/main.rs
+++ b/examples/transfers/enclave/src/main.rs
@@ -70,6 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(not(feature = "mock-sgx"))]
     let attestor = attestor::DcapAttestor {
         fmspc: args.fmspc.expect("FMSPC is required for DCAP"),
+        pccs_url: args.pccs_url.expect("PCCS URL is required for DCAP"),
     };
 
     #[cfg(feature = "mock-sgx")]

--- a/examples/transfers/sgx_default_qcnl.conf
+++ b/examples/transfers/sgx_default_qcnl.conf
@@ -5,7 +5,7 @@
     "pccs_url": "https://global.acccache.azure.net/sgx/certification/v4/"
   
     // To accept insecure HTTPS certificate, set this option to false
-    ,"use_secure_cert": false
+    ,"use_secure_cert": true
   
     // You can use the Intel PCS or another PCCS to get quote verification collateral.  Retrieval of PCK
     // Certificates will always use the PCCS described in pccs_url.  When collateral_service is not defined, both


### PR DESCRIPTION
# What's in this PR
- Updates to Gramine manifests to support newer versions and disable EPID completely.
- Simplify installation by using Azure PCCS directly (avoid local PCCS installation) - this needed code modifications to allow users to specify `PCCS_URL` at the time of enclave instantiation. 
- Update Azure installation instructions for Ubuntu 24.04 LTS.

# Setup instructions
- These instructions have been tested twice from scratch, but I recommend the reviewer run them again. (Probably better to run the instructions from the getting_started.md doc, so we're sure we're testing exactly what we're documenting)
- I intentionally left out the neutron client setup because that's already documented separately in the getting_started.md. Also left out DCAP contract deployment for the same reason. 
```
sudo apt update
sudo apt upgrade
sudo reboot

# --- setup
sudo apt install -y dkms \
		build-essential \
		curl \
		gnupg2 \
		binutils \
		clang \
		libclang-dev \
		pkg-config \
		libssl-dev \
		protobuf-compiler

# gramine and DCAP
# either build from source or install with apt as follows
# see https://github.com/gramineproject/gramine/blob/master/packaging/docker/Dockerfile
export UBUNTU_CODENAME=$(lsb_release -sc)
sudo curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring-${UBUNTU_CODENAME}.gpg \
    && sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ '${UBUNTU_CODENAME}' main' \
    | sudo tee /etc/apt/sources.list.d/gramine.list
sudo curl -fsSLo /usr/share/keyrings/intel-sgx-deb.key https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \
    && sudo echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx-deb.key] https://download.01.org/intel-sgx/sgx_repo/ubuntu '${UBUNTU_CODENAME}' main' \
    | sudo tee /etc/apt/sources.list.d/intel-sgx.list
sudo apt update && \
    sudo apt install -y gramine \
    sgx-aesm-service \
    libsgx-enclave-common \
    libsgx-aesm-launch-plugin \
    libsgx-aesm-quote-ex-plugin \
    libsgx-aesm-ecdsa-plugin \
    libsgx-dcap-quote-verify \
    libsgx-dcap-ql \
    libsgx-dcap-default-qpl \
    libsgx-dcap-quote-verify \
    psmisc && \
    sudo apt clean && \
    sudo rm -rf /var/lib/apt/lists/* && \
    sudo apt update

# (optionally) test gramine
gramine-sgx-gen-private-key
git clone https://github.com/gramineproject/gramine.git
cd gramine/CI-Examples/helloworld
make SGX=1
gramine-sgx ./helloworld

# start aesm (copied from Gramine's Dockerfile)
cat <<EOF > restart_aesm.md
#!/bin/sh
set -e
killall -q aesm_service || true
AESM_PATH=/opt/intel/sgx-aesm-service/aesm LD_LIBRARY_PATH=/opt/intel/sgx-aesm-service/aesm exec /opt/intel/sgx-aesm-service/aesm/aesm_service --no-syslog
EOF
chmod +x restart_aesm.sh
sudo ./restart_aesm.sh

# --- Quartz setup

# rust
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
. "$HOME/.cargo/env"
rustup target add wasm32-unknown-unknown

# --- install neutron 
# install go (1.23.4 => because that's what neutron needs)
wget https://go.dev/dl/go1.23.4.linux-amd64.tar.gz
sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.23.4.linux-amd64.tar.gz
echo "export PATH=\$PATH:/usr/local/go/bin" >> ~/.profile
echo "export PATH=\$PATH:~/go/bin" >> ~/.profile
. ~/.profile
git clone -b main https://github.com/neutron-org/neutron.git
cd neutron/
make install
# neutrond version

# setup neutrond client (see below)

# install quartz-cli
git clone https://github.com/informalsystems/quartz.git
cd quartz
git checkout hu55a1n1/azure-focal-fixes
cargo install --path crates/cli

# setup PCCS correctly
sudo cp examples/transfers/sgx_default_qcnl.conf /etc/sgx_default_qcnl.conf
sudo ~/restart_aesm.sh

# --- run quartz (below same as before)
# you might want to update the tcbinfo contract you can follow the steps following [this guide from line 32 ](./tcbinfo_and_verifier.md).
# here we're using the pre-deployed neutron pion-1 testnet contracts
export PCCS_URL="https://global.acccache.azure.net/sgx/certification/v4/"
export TCBINFO_CONTRACT=neutron1anj45ushmjntew7zrg5jw2rv0rwfce3nl5d655mzzg8st0qk4wjsds4wps
export DCAP_CONTRACT=neutron18f3xu4yazfqr48wla9dwr7arn8wfm57qfw8ll6y02qsgmftpft6qfec3uf
export ADMIN_SK=ffc4d3c9119e9e8263de08c0f6e2368ac5c2dacecfeb393f6813da7d178873d2

# go to the transfers example dir and copy the neutron testnet config file to the default quartz.toml file, so we connect to the right nodes
cd examples/transfers
cp quartz.neutron_pion-1.toml quartz.toml

# retrieve the FMSPC from your machine
quartz print-fmspc --pccs-url $PCCS_URL

# export it
export FMSPC=<YOUR MACHINE FMSPC HERE>  # e.g. 00606A000000

# build and start the enclave
quartz enclave build
quartz enclave start --fmspc $FMSPC \
    --pccs-url $PCCS_URL \
    --tcbinfo-contract $TCBINFO_CONTRACT \
    --dcap-verifier-contract $DCAP_CONTRACT \
    --unsafe-trust-latest

# build and deploy the contracts
quartz contract build --contract-manifest "contracts/Cargo.toml"
quartz contract deploy --contract-manifest "contracts/Cargo.toml" --init-msg '{"denom":"untrn"}'

# store the output
export CONTRACT=<CONTRACT_ADDRESS>

# create the handshake
quartz handshake --contract $CONTRACT
```

## TODOs
- [ ] Delete unused Azure resources