### PR TITLE
cli: add wasm_bin_path flag

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -214,6 +214,13 @@ pub struct ContractDeployArgs {
     /// Path to Cargo manifest file for CosmWasm contract package
     #[arg(long, default_value = "./contracts/Cargo.toml")]
     pub contract_manifest: PathBuf,
+
+    /// Path to Wasm binary file for CosmWasm contract package
+    /// If not provided, the wasm binary will be built using the contract manifest
+    /// otherwise the provided wasm binary will be used
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wasm_bin_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Parser, Clone, Serialize, Deserialize)]

--- a/crates/cli/src/handler/contract_deploy.rs
+++ b/crates/cli/src/handler/contract_deploy.rs
@@ -40,8 +40,8 @@ impl Handler for ContractDeployRequest {
 
         // take the wasm bin path from the args if provided, otherwise use the default
         let wasm_bin_path = {
-            if self.wasm_bin_path.is_some() {
-                self.wasm_bin_path.clone().unwrap()
+            if let Some(path) = self.wasm_bin_path.clone() {
+                path
             } else {
                 config
                     .app_dir

--- a/crates/cli/src/handler/contract_deploy.rs
+++ b/crates/cli/src/handler/contract_deploy.rs
@@ -38,11 +38,18 @@ impl Handler for ContractDeployRequest {
             .clone()
             .replace('-', "_");
 
-        let wasm_bin_path = config
-            .app_dir
-            .join("target/wasm32-unknown-unknown/release")
-            .join(package_name)
-            .with_extension("wasm");
+        // take the wasm bin path from the args if provided, otherwise use the default
+        let wasm_bin_path = {
+            if self.wasm_bin_path.is_some() {
+                self.wasm_bin_path.clone().unwrap()
+            } else {
+                config
+                    .app_dir
+                    .join("target/wasm32-unknown-unknown/release")
+                    .join(package_name)
+                    .with_extension("wasm")
+            }
+        };
 
         let (code_id, contract_addr) = deploy(wasm_bin_path.as_path(), self, config).await?;
 

--- a/crates/cli/src/handler/dev.rs
+++ b/crates/cli/src/handler/dev.rs
@@ -76,14 +76,23 @@ async fn dev_driver(
                 let enclave_build = EnclaveBuildRequest {};
                 enclave_build.handle(&config).await?;
 
-                // Build contract
-                let contract_build = ContractBuildRequest {
-                    contract_manifest: args.contract_manifest.clone(),
-                };
-                contract_build
-                    .handle(&config)
-                    .await
-                    .wrap_err("Could not run `contract build`")?;
+                // Build contract unless wasm bin path is provided
+                if args.wasm_bin_path.is_none() {
+                    let contract_build = ContractBuildRequest {
+                        contract_manifest: args.contract_manifest.clone(),
+                    };
+                    contract_build
+                        .handle(&config)
+                        .await
+                        .wrap_err("Could not run `contract build`")?;
+                } else {
+                    info!(
+                        "{}",
+                        "wasm_bin_path provided - skipping contract build..."
+                            .green()
+                            .bold()
+                    );
+                }
 
                 // Start enclave in background
                 let restored = spawn_enclave_start(args, &config)?;

--- a/crates/cli/src/handler/dev.rs
+++ b/crates/cli/src/handler/dev.rs
@@ -229,6 +229,7 @@ async fn deploy_and_handshake(
             admin: args.admin.clone(),
             no_admin: args.no_admin,
             contract_manifest: args.contract_manifest.clone(),
+            wasm_bin_path: args.wasm_bin_path.clone(),
         };
         // Call handler
         let cd_res = contract_deploy

--- a/crates/cli/src/handler/enclave_build.rs
+++ b/crates/cli/src/handler/enclave_build.rs
@@ -37,7 +37,7 @@ impl Handler for EnclaveBuildRequest {
             command.arg("--release");
         }
 
-        info!("{}", "🚧 Running build command ...".green().bold());
+        info!("{}", "🚧 Running enclave build command ...".green().bold());
         let status = command.status().await?;
 
         if !status.success() {

--- a/crates/cli/src/request.rs
+++ b/crates/cli/src/request.rs
@@ -64,6 +64,7 @@ impl TryFrom<Command> for Request {
                     fmspc: args.fmspc,
                     tcbinfo_contract: args.tcbinfo_contract,
                     dcap_verifier_contract: args.dcap_verifier_contract,
+                    wasm_bin_path: args.contract_deploy.wasm_bin_path,
                 }
                 .into())
             }
@@ -93,6 +94,7 @@ impl TryFrom<ContractCommand> for Request {
                     admin: args.admin,
                     no_admin: args.no_admin,
                     contract_manifest: args.contract_manifest,
+                    wasm_bin_path: args.wasm_bin_path,
                 }
                 .into())
             }

--- a/crates/cli/src/request/contract_deploy.rs
+++ b/crates/cli/src/request/contract_deploy.rs
@@ -12,6 +12,7 @@ pub struct ContractDeployRequest {
     pub admin: Option<String>,
     pub no_admin: bool,
     pub contract_manifest: PathBuf,
+    pub wasm_bin_path: Option<PathBuf>,
 }
 
 impl From<ContractDeployRequest> for Request {

--- a/crates/cli/src/request/dev.rs
+++ b/crates/cli/src/request/dev.rs
@@ -18,6 +18,7 @@ pub struct DevRequest {
     pub fmspc: Option<Fmspc>,
     pub tcbinfo_contract: Option<AccountId>,
     pub dcap_verifier_contract: Option<AccountId>,
+    pub wasm_bin_path: Option<PathBuf>,
 }
 
 impl From<DevRequest> for Request {


### PR DESCRIPTION
Adds `--wasm-bin-path` CLI argument.

When this is provided the tool will skip building the CW contract and instead continue with contract upload and instantiate operations when running `quartz dev` and `quartz contract deploy`.

The `--contract-manifest` flag is still required for obtaining contract metadata. This new flag only allows for skipping over the contract build step since we need to deploy optimized contracts.