### PR TITLE
feat(cli): `--bin-path` arg for enclave start and dev commands

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -268,6 +268,11 @@ pub struct EnclaveStartArgs {
     #[arg(long)]
     #[serde(skip_serializing_if = "is_false")]
     pub release: bool,
+
+    /// Path to the enclave executable (only used in mock-sgx mode)
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bin_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Parser, Clone, Serialize, Deserialize)]
@@ -300,6 +305,11 @@ pub struct DevArgs {
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dcap_verifier_contract: Option<AccountId>,
+
+    /// Path to the enclave executable (only used in mock-sgx mode)
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bin_path: Option<PathBuf>,
 }
 
 #[serde_as]

--- a/crates/cli/src/handler/dev.rs
+++ b/crates/cli/src/handler/dev.rs
@@ -181,6 +181,7 @@ fn spawn_enclave_start(args: &DevRequest, config: &Config) -> Result<bool> {
     // In separate process, launch the enclave
     let enclave_start = EnclaveStartRequest {
         unsafe_trust_latest: args.unsafe_trust_latest,
+        bin_path: args.bin_path.clone(),
         fmspc: args.fmspc.clone(),
         pccs_url: None,
         tcbinfo_contract: args.tcbinfo_contract.clone(),

--- a/crates/cli/src/request.rs
+++ b/crates/cli/src/request.rs
@@ -65,6 +65,7 @@ impl TryFrom<Command> for Request {
                     tcbinfo_contract: args.tcbinfo_contract,
                     dcap_verifier_contract: args.dcap_verifier_contract,
                     wasm_bin_path: args.contract_deploy.wasm_bin_path,
+                    bin_path: args.bin_path,
                 }
                 .into())
             }
@@ -123,6 +124,7 @@ impl TryFrom<EnclaveCommand> for Request {
             EnclaveCommand::Build(_) => Ok(EnclaveBuildRequest {}.into()),
             EnclaveCommand::Start(args) => Ok(EnclaveStartRequest {
                 unsafe_trust_latest: args.unsafe_trust_latest,
+                bin_path: args.bin_path,
                 fmspc: args.fmspc,
                 pccs_url: args.pccs_url,
                 tcbinfo_contract: args.tcbinfo_contract,

--- a/crates/cli/src/request/dev.rs
+++ b/crates/cli/src/request/dev.rs
@@ -19,6 +19,7 @@ pub struct DevRequest {
     pub tcbinfo_contract: Option<AccountId>,
     pub dcap_verifier_contract: Option<AccountId>,
     pub wasm_bin_path: Option<PathBuf>,
+    pub bin_path: Option<PathBuf>,
 }
 
 impl From<DevRequest> for Request {

--- a/crates/cli/src/request/enclave_start.rs
+++ b/crates/cli/src/request/enclave_start.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use color_eyre::Result;
 use cosmrs::AccountId;
 use quartz_common::enclave::types::Fmspc;
@@ -10,6 +12,7 @@ use crate::{config::Config, handler::utils::helpers::query_latest_height_hash, r
 #[derive(Clone, Debug)]
 pub struct EnclaveStartRequest {
     pub unsafe_trust_latest: bool,
+    pub bin_path: Option<PathBuf>,
     pub fmspc: Option<Fmspc>,
     pub pccs_url: Option<Url>,
     pub tcbinfo_contract: Option<AccountId>,


### PR DESCRIPTION
Works as expected with -> 
```sh
$ RUST_LOG=debug quartz --mock-sgx dev --contract-manifest "./contracts/Cargo.toml" --unsafe-trust-latest --init-msg '{"denom": "ucosm"}' --bin-path `pwd`/target/release/quartz-app-transfers-enclave
```
Or -> 
```sh
$ RUST_LOG=debug quartz --mock-sgx enclave run --unsafe-trust-latest --bin-path `pwd`/target/release/quartz-app-transfers-enclave
```